### PR TITLE
Add Private Aggregation testing

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -66,7 +66,7 @@
     },
     "hosting": {
       "host": "localhost",
-      "port": "8080"
+      "port": "3000"
     },
     "ui": {
       "enabled": true

--- a/functions/.env.local
+++ b/functions/.env.local
@@ -1,4 +1,4 @@
-DEMO_HOME_URL="http://localhost:8080"
+DEMO_HOME_URL="http://localhost:3000"
 CONTENT_PRODUCER_URL="https://localhost:4437"
-PUBLISHER_A_URL="http://localhost:8085"
-PUBLISHER_B_URL="http://localhost:8086"
+PUBLISHER_A_URL="http://localhost:3005"
+PUBLISHER_B_URL="http://localhost:3006"

--- a/functions/app/content-producer/index.js
+++ b/functions/app/content-producer/index.js
@@ -16,12 +16,16 @@
 const express = require('express');
 const functions = require('firebase-functions');
 const setupView = require('../helpers/setup-view');
+const setupPrivateAggregationTestRoutes = require('./setup-paa-test-routes');
 
 // Read the dev or prod URLs to be used
 require('dotenv').config({ path: `.env.${process.env.NODE_ENV}` });
 
 // Setup app and view
 const app = setupView(express(), 'content-producer');
+
+// Setup Private Aggregation API test routes
+setupPrivateAggregationTestRoutes(app);
 
 // Setup root route
 app.get('/', (req, res) => {
@@ -64,12 +68,6 @@ app.post('/report/hover', (req, res) => {
   console.log('\x1b[1;31m%s\x1b[0m', `🚀 You have received an event-level report from the browser`);
   console.log('QUERY PARAMS RECEIVED (event-level):\n=== \n', req.query, '\n=== \n');
   console.log('PAYLOAD RECEIVED (event-level):\n=== \n', req.body, '\n=== \n');
-  res.sendStatus(200);
-});
-
-app.post('/.well-known/private-aggregation/report-shared-storage', (req, res) => {
-  console.log('\x1b[1;31m%s\x1b[0m', `🚀 You have received an event-level report from the browser`);
-  console.log('REGULAR REPORT RECEIVED (event-level):\n=== \n', req.body, '\n=== \n');
   res.sendStatus(200);
 });
 

--- a/functions/app/content-producer/paa/scripts/private-aggregation-test-worklet.js
+++ b/functions/app/content-producer/paa/scripts/private-aggregation-test-worklet.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const DEBUG_MODE_CHANCE = 0.5;
+
+class PrivateAggregationTest {
+  async run() {
+    const testKey = await this.sharedStorage.get('test-key');
+    const testValue = await this.sharedStorage.get('test-value');
+
+    if (Math.random() < DEBUG_MODE_CHANCE) {
+      // The debug key is a random 15 or 16 digit integer
+      const debug_key = BigInt(Math.round(Math.random() * 1e16));
+      privateAggregation.enableDebugMode({ debug_key });
+    }
+
+    privateAggregation.sendHistogramReport({
+      bucket: BigInt(testKey),
+      value: parseInt(testValue),
+    });
+  }
+}
+
+register('private-aggregation-test', PrivateAggregationTest);

--- a/functions/app/content-producer/paa/scripts/private-aggregation-test.html
+++ b/functions/app/content-producer/paa/scripts/private-aggregation-test.html
@@ -1,0 +1,61 @@
+<!--
+ Copyright 2023 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" />
+  <meta name="description" content="Private Aggregation API testing" />
+  <title>Private Aggregation API testing</title>
+  <script>
+    const ORIGIN_TRIAL_TOKEN =
+      'A7hH9M5YSi7PanBca+ZM1gmLeyS2N39jVtswueCTflf6PHJ0KpcYR4OGhxv1gkiOMRmXhYjPMaO3nADEWKEf4gYAAAB+eyJvcmlnaW4iOiJodHRwczovL3NoYXJlZC1zdG9yYWdlLWRlbW8ud2ViLmFwcDo0NDMiLCJmZWF0dXJlIjoiUHJpdmFjeVNhbmRib3hBZHNBUElzIiwiZXhwaXJ5IjoxNjg4MDgzMTk5LCJpc1RoaXJkUGFydHkiOnRydWV9';
+
+    function setup3pOriginTrialToken() {
+      const otMeta = document.createElement('meta');
+      otMeta.httpEquiv = 'origin-trial';
+      otMeta.content = ORIGIN_TRIAL_TOKEN;
+      document.head.append(otMeta);
+    }
+
+    async function runPrivateAggregationTest() {
+      // The key is a random 5 or 6 digit integer
+      window.sharedStorage.set('test-key', Math.round(Math.random() * 1e6));
+      // The value is a random single digit integer
+      window.sharedStorage.set('test-value', Math.round(Math.random() * 10));
+
+      await window.sharedStorage.worklet.addModule(
+        `https://shared-storage-demo-content-producer.web.app/paa/scripts/private-aggregation-test-worklet.js`
+      );
+
+      window.sharedStorage.run('private-aggregation-test');
+    }
+
+    try {
+      setup3pOriginTrialToken();
+
+      if ('sharedStorage' in window) {
+        runPrivateAggregationTest();
+      }
+    } catch {}
+  </script>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/functions/app/content-producer/paa/scripts/private-aggregation-test.js
+++ b/functions/app/content-producer/paa/scripts/private-aggregation-test.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function setupIframe() {
+  const body = document.querySelector('body');
+  const iframe = document.createElement('iframe');
+
+  iframe.style.height = 0;
+  iframe.style.width = 0;
+  iframe.style.top = 0;
+  iframe.style.position = 'absolute';
+  iframe.src = `https://shared-storage-demo-content-producer.web.app/paa/scripts/private-aggregation-test.html`;
+
+  body.appendChild(iframe);
+}
+
+try {
+  setupIframe();
+} catch {
+  // Swallow the error
+}

--- a/functions/app/content-producer/setup-paa-test-routes.js
+++ b/functions/app/content-producer/setup-paa-test-routes.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const fs = require('fs');
+const cors = require('cors');
+
+function setupPrivateAggregationTestRoutes(app) {
+  app.post('/.well-known/private-aggregation/report-shared-storage', (req, res) => {
+    console.log('\x1b[1;31m%s\x1b[0m', `🚀 You have received an event-level report from the browser`);
+    console.log('REGULAR REPORT RECEIVED (event-level):\n=== \n', req.body, '\n=== \n');
+    res.sendStatus(200);
+  });
+
+  app.post('/.well-known/debug/private-aggregation/report-shared-storage', (req, res) => {
+    console.log('\x1b[1;31m%s\x1b[0m', `🚀 You have received an event-level report from the browser`);
+    console.log('DEBUG REPORT RECEIVED (event-level):\n=== \n', req.body, '\n=== \n');
+    res.sendStatus(200);
+  });
+
+  app.get('/paa/get-reports', (req, res) => {});
+
+  app.get('/paa/scripts/private-aggregation-test.js', cors(), async (req, res) => {
+    let response;
+
+    try {
+      response = await fs.promises.readFile(`${__dirname}/paa/scripts/private-aggregation-test.js`, 'utf8');
+    } catch (e) {
+      console.error(e);
+      res.status(500);
+    }
+
+    res.send(response);
+  });
+
+  app.get('/paa/scripts/private-aggregation-test.html', cors(), async (req, res) => {
+    let response;
+
+    try {
+      response = await fs.promises.readFile(`${__dirname}/paa/scripts/private-aggregation-test.html`, 'utf8');
+    } catch (e) {
+      console.error(e);
+      res.status(500);
+    }
+
+    res.send(response);
+  });
+
+  app.get('/paa/scripts/private-aggregation-test-worklet.js', async (req, res) => {
+    let response;
+
+    try {
+      response = await fs.promises.readFile(`${__dirname}/paa/scripts/private-aggregation-test-worklet.js`, 'utf8');
+    } catch (e) {
+      console.error(e);
+      res.status(500);
+    }
+
+    res.type('.js');
+    res.send(response);
+  });
+}
+
+module.exports = setupPrivateAggregationTestRoutes;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,31 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "license": "ISC",
+      "dependencies": {
+        "cors": "^2.8.5"
+      },
       "devDependencies": {
         "prettier": "^2.6.2"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prettier": {
@@ -27,14 +50,41 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     }
   },
   "dependencies": {
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+    },
     "prettier": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
       "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
       "dev": true
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "license": "ISC",
   "devDependencies": {
     "prettier": "^2.6.2"
+  },
+  "dependencies": {
+    "cors": "^2.8.5"
   }
 }


### PR DESCRIPTION
This PR adds Private Aggregation API testing. 

New routes: 
* GET /paa/scripts
* POST /.well-known/private-aggregation/report-shared-storage
* POST /.well-known/debug/private-aggregation/report-shared-storage

New major files: 
* `private-aggregation-test.js` - The initial file imported by the embedder.  Injects an iframe on the page. 
* `private-aggregation-test.html` - Rendered into the injected iframe.  Sets up the test and loads the worklet.
* `private-aggregation-test-worklet.js` - Worklet that contains the PAA code. 