### PR TITLE
Reframe ‘Frequency Capping’ terminology to ‘Creative Selection by Frequency’ 

### DIFF
--- a/functions/view/home/index.hbs
+++ b/functions/view/home/index.hbs
@@ -162,21 +162,20 @@
         </p>
       </div>
       <card class='demo__card--frequency-cap'>
-        <h4>Frequency cap</h4>
+        <h4>Creative selection by frequency</h4>
         <div class='demo__button-container'>
-          <button class='demo__button' onclick="window.open('{{{publisherAUrl}}}/frequency-cap', '_self')">Publisher A</button>
-          <button class='demo__button' onclick="window.open('{{{publisherBUrl}}}/frequency-cap', '_self')">Publisher B</button>
+          <button class='demo__button' onclick="window.open('{{{publisherAUrl}}}/creative-selection-by-frequency', '_self')">Publisher A</button>
+          <button class='demo__button' onclick="window.open('{{{publisherBUrl}}}/creative-selection-by-frequency', '_self')">Publisher B</button>
         </div>
         <p>
-          When the same ad is shown to the user repeatedly, the ad starts to lose its effectiveness. Frequency capping
-          allows an advertiser to limit the number of times an ad can be shown to a user.
+          If an ad creative has been shown to the user too many times, select a different ad.
         </p>
         <p>
-          In this demo, the frequency cap has been set to 5. When the user sees the same example ad 5 times across both
+          In this demo, when the user sees the same example ad 5 times across both
           <b>Publisher A</b>
           and
           <b>Publisher B</b>
-          sites, the default ad will be rendered. The demo contains a button to reset the count back to 5.
+          sites, the default ad will be selected. The demo contains a button to reset the frequency back to 5.
         </p>
       </card>
       <card class='demo__card--creative-rotation'>

--- a/functions/view/publisher-a/creative-selection-by-frequency.hbs
+++ b/functions/view/publisher-a/creative-selection-by-frequency.hbs
@@ -1,7 +1,7 @@
 <main class='demo-container'>
   <div class='demo__navigation'>
     <p>
-      [<a href='{{{demoHomeUrl}}}'> Return to main page </a>] [<a href='{{{publisherBUrl}}}/frequency-cap'>
+      [<a href='{{{demoHomeUrl}}}'> Return to main page </a>] [<a href='{{{publisherBUrl}}}/creative-selection-by-frequency'>
         Go to "Publisher B" page
       </a>]
     </p>
@@ -10,32 +10,31 @@
     <card class='demo__publisher-badge demo__publisher-badge--publisher-a'>
       <h5>Publisher A</h5>
     </card>
-    <h3>Shared storage - Frequency cap demo</h3>
+    <h3>Shared storage - Creative selection by frequency demo</h3>
   </div>
   <div class='demo__content'>
-    <iframe class='demo__dsp-iframe' src='{{{contentProducerUrl}}}/url-selection/frequency-cap.html'></iframe>
+    <iframe class='demo__dsp-iframe' src='{{{contentProducerUrl}}}/url-selection/creative-selection-by-frequency.html'></iframe>
     <card class='demo__description'>
       <h4>Description</h4>
       <p>
-        When the same ad is shown to the user repeatedly, the ad starts to lose its effectiveness. Frequency capping
-        allows an advertiser to limit the number of times an ad can be shown to a user.
+        If an ad creative has been shown to the user too many times, select a different ad.
       </p>
-      <p>
-        In this demo, the frequency cap has been set to 5. When the user sees the same example ad 5 times across both
-        <b>Publisher A</b>
-        and
-        <b>Publisher B</b>
-        sites, the default ad will be rendered. The demo contains a button to reset the count back to 5.
-      </p>
+        <p>
+          In this demo, when the user sees the same example ad 5 times across both
+          <b>Publisher A</b>
+          and
+          <b>Publisher B</b>
+          sites, the default ad will be selected. The demo contains a button to reset the frequency back to 5.
+        </p>
       <h4>Code</h4>
       <ul>
         <li><a
-            href='https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/content-producer/url-selection/frequency-cap.js'
+            href='https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/content-producer/url-selection/creative-selection-by-frequency.js'
             target='_blank'
           >Iframe logic</a>
           (embedded into the publisher page)</li>
         <li><a
-            href='https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/content-producer/url-selection/frequency-cap-worklet.js'
+            href='https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/content-producer/url-selection/creative-selection-by-frequency-worklet.js'
             target='_blank'
           >Worklet</a>
           (loaded and executed by the iframe logic)</li>

--- a/functions/view/publisher-b/creative-selection-by-frequency.hbs
+++ b/functions/view/publisher-b/creative-selection-by-frequency.hbs
@@ -1,7 +1,7 @@
 <main class='demo-container'>
   <div class='demo__navigation'>
     <p>
-      [<a href='{{{demoHomeUrl}}}'> Return to main page </a>] [<a href='{{{publisherAUrl}}}/frequency-cap'>
+      [<a href='{{{demoHomeUrl}}}'> Return to main page </a>] [<a href='{{{publisherAUrl}}}/creative-selection-by-frequency'>
         Go to "Publisher A" page
       </a>]
     </p>
@@ -10,32 +10,31 @@
     <card class='demo__publisher-badge demo__publisher-badge--publisher-b'>
       <h5>Publisher B</h5>
     </card>
-    <h3>Shared storage - Frequency cap demo</h3>
+    <h3>Shared storage - Creative selection by frequency demo</h3>
   </div>
   <div class='demo__content'>
-    <iframe class='demo__dsp-iframe' src='{{{contentProducerUrl}}}/url-selection/frequency-cap.html'></iframe>
+    <iframe class='demo__dsp-iframe' src='{{{contentProducerUrl}}}/url-selection/creative-selection-by-frequency.html'></iframe>
     <card class='demo__description'>
       <h4>Description</h4>
       <p>
-        When the same ad is shown to the user repeatedly, the ad starts to lose its effectiveness. Frequency capping
-        allows an advertiser to limit the number of times an ad can be shown to a user.
+        If an ad creative has been shown to the user too many times, select a different ad.
       </p>
-      <p>
-        In this demo, the frequency cap has been set to 5. When the user sees the same example ad 5 times across both
-        <b>Publisher A</b>
-        and
-        <b>Publisher B</b>
-        sites, the default ad will be rendered. The demo contains a button to reset the count back to 5.
-      </p>
+        <p>
+          In this demo, when the user sees the same example ad 5 times across both
+          <b>Publisher A</b>
+          and
+          <b>Publisher B</b>
+          sites, the default ad will be selected. The demo contains a button to reset the frequency back to 5.
+        </p>
       <h4>Code</h4>
       <ul>
         <li><a
-            href='https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/content-producer/url-selection/frequency-cap.js'
+            href='https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/content-producer/url-selection/creative-selection-by-frequency.js'
             target='_blank'
           >Iframe logic</a>
           (embedded into the publisher page)</li>
         <li><a
-            href='https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/content-producer/url-selection/frequency-cap-worklet.js'
+            href='https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/content-producer/url-selection/creative-selection-by-frequency-worklet.js'
             target='_blank'
           >Worklet</a>
           (loaded and executed by the iframe logic)</li>

--- a/sites/content-producer/url-selection/creative-selection-by-frequency-worklet.js
+++ b/sites/content-producer/url-selection/creative-selection-by-frequency-worklet.js
@@ -14,26 +14,28 @@
  * limitations under the License.
  */
 
-class SelectURLOperation {
+const FREQUENCY_LIMIT = 5;
+
+class CreativeSelectionByFrequencyOperation {
   async run(urls, data) {
     // Read the current frequency cap in shared storage
-    const count = parseInt(await this.sharedStorage.get('frequency-cap-count'));
+    const count = parseInt(await this.sharedStorage.get('frequency-count'));
 
     // Log to console for the demo
     console.log(`urls = ${JSON.stringify(urls)}`);
-    console.log(`frequency-cap-count in shared storage is ${count}`);
+    console.log(`frequency-count in shared storage is ${count}`);
 
     // If the count is 0, the frequency cap has been reached
-    if (count === 0) {
-      console.log('frequency cap has been reached, and the default ad will be rendered');
+    if (count === FREQUENCY_LIMIT) {
+      console.log('frequency limit has been reached, and the default ad will be rendered');
       return 0;
     }
 
-    // Set the new frequency count in shared storage
-    await this.sharedStorage.set('frequency-cap-count', (count - 1).toString());
+    // Increment the frequency
+    await this.sharedStorage.set('frequency-count', count + 1);
     return 1;
   }
 }
 
-// Register the operation as 'frequency-cap'
-register('frequency-cap', SelectURLOperation);
+// Register the operation
+register('creative-selection-by-frequency', CreativeSelectionByFrequencyOperation);

--- a/sites/content-producer/url-selection/creative-selection-by-frequency.html
+++ b/sites/content-producer/url-selection/creative-selection-by-frequency.html
@@ -29,11 +29,11 @@
       href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🙂</text></svg>"
     />
     <link rel="stylesheet" href="../demo.css" />
-    <script src="frequency-cap.js"></script>
+    <script src="creative-selection-by-frequency.js"></script>
     <script>
       // This button is for resetting the demo, and is not part of the core logic
       function resetSharedStorage() {
-        window.sharedStorage.set('frequency-cap-count', '5');
+        window.sharedStorage.set('frequency-count', 0);
       }
     </script>
   </head>
@@ -44,7 +44,7 @@
       <h5>Demo control</h5>
       <div class="demo__buttons-container">
         <button class="mdl-button mdl-js-button mdl-button--raised demo__button" onclick="resetSharedStorage()">
-          Reset frequency cap to 5
+          Reset frequency count
         </button>
       </div>
     </div>

--- a/sites/content-producer/url-selection/creative-selection-by-frequency.js
+++ b/sites/content-producer/url-selection/creative-selection-by-frequency.js
@@ -25,15 +25,15 @@ const AD_URLS = [
 
 async function injectAd() {
   // Load the worklet module
-  await window.sharedStorage.worklet.addModule('frequency-cap-worklet.js');
+  await window.sharedStorage.worklet.addModule('creative-selection-by-frequency-worklet.js');
 
   // Set the initial frequency cap to 5
-  window.sharedStorage.set('frequency-cap-count', 5, {
+  window.sharedStorage.set('frequency-count', 0, {
     ignoreIfPresent: true,
   });
 
   // Run the URL selection operation to choose an ad based on the frequency cap in shared storage
-  const opaqueURL = await window.sharedStorage.selectURL('frequency-cap', AD_URLS);
+  const opaqueURL = await window.sharedStorage.selectURL('creative-selection-by-frequency', AD_URLS);
 
   // Render the opaque URL into a fenced frame
   document.getElementById('ad-slot').src = opaqueURL;


### PR DESCRIPTION
This PR updates the ‘Frequency Capping/Control’ terminology used in URL selection use cases to minimize confusion and align with industry colloquialism. 

Select URL is a post auction content filtering mechanism that can be used to select one of 8 URLs using cross-site data. One of the key use cases involves storing the number of ads a user has seen across sites in Shared Storage, and using this information to choose the next ad to serve. If the user has seen too many of one ad, they could be shown a new ad or the default ad. 

We were previously referring to this use case as ‘Frequency Capping’ or ‘Frequency Control’. However, we have heard feedback that the industry tends to use those terms when an advertiser is prevented from bidding and prevented from showing the user any ad at all, rather than selecting a different ad. As a result we have reframed the terminology to more explicitly describe the capability, i.e. ‘Creative Selection by Frequency.’ 