### PR TITLE
Add third-party write destination demo

### DIFF
--- a/functions/view/home/index.hbs
+++ b/functions/view/home/index.hbs
@@ -59,6 +59,18 @@
           Whenever the fenced frame navigates the top-level frame to another page, the <a href="https://github.com/WICG/shared-storage#budgeting" target="_blank">entropy budget</a> is decreased. This demo shows allows you to see how the budget decreases.
         </p>
       </card>
+      <card class='demo__card--top-level-nav'>
+        <h4>Controlling where third-party can write to</h4>
+        <div class='demo__button-container'>
+          <button
+            class='demo__button'
+            onclick="window.open('{{{publisherAUrl}}}/third-party-write', '_self')"
+          >Publisher</button>
+        </div>
+        <p>
+          When a third-party code is added to the publisher's page, the third-party can write to the shared storage of their own origin, or write to the publisher's origin. This demo illustrates the mechanisms for controlling the document origin that determines whose shared storage that data is written into.
+        </p>
+      </card>
     </section>
     <section class='demo__gate-container'>
       <div class='demo__gate-header'>

--- a/functions/view/publisher-a/third-party-write.hbs
+++ b/functions/view/publisher-a/third-party-write.hbs
@@ -1,0 +1,59 @@
+
+<main class='demo-container'>
+  <div class='demo__navigation'>
+    <p>[<a href='{{{demoHomeUrl}}}'> Return to main page </a>]</p>
+  </div>
+  <div class='demo__header'>
+    <card class='demo__publisher-badge demo__publisher-badge--publisher-a'>
+      <h5>Publisher A</h5>
+    </card>
+    <h3>Shared storage - Third-party write destination demo</h3>
+  </div>
+  <div class='demo__content'>
+
+    {{!-- This third-party script writes data to the publisher's shared storage --}}
+    <script src='{{{contentProducerUrl}}}/use-cases/third-party-write.js'></script>
+
+    {{!-- This third-party iframe's code writes data to its own shared storage --}}
+    <iframe class='demo__dsp-iframe' src='{{{contentProducerUrl}}}/use-cases/third-party-write.html'></iframe>
+
+    <card class='demo__description'>
+      <h4>Description</h4>
+      <p>
+        When a third-party code is added to the publisher's page, the third-party can write to the shared storage of their own origin, or write to the publisher's origin.
+      </p>
+      <p>
+        Using a <code>script</code> tag allows the third-party code to be injected in the publisher's context, and using an <code>iframe</code> to load third-party code allows third-party to write to its own shared storage.
+      </p>
+      <h4>Code</h4>
+      <ul>
+        <li><a
+            href='https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/content-producer/use-cases/third-party-write.html'
+            target='_blank'
+          >Code for third-party to write into its own shared storage</a>
+        </li>
+        <li><a
+            href='https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/content-producer/use-cases/third-party-write.js'
+            target='_blank'
+          >Code for third-party to write into publisher's shared storage</a>
+          </li>
+      </ul>
+    </card>
+  </div>
+  <card class='demo__instructions'>
+    <p>
+      Shared Storage API is not enabled in your browser. Follow the
+      <a
+        href='https://developer.chrome.com/docs/privacy-sandbox/shared-storage/#try-the-shared-storage-api'
+        target='_blank'
+      >instructions</a>, and enable the the
+      <b>Privacy Sandbox Ads APIs</b>
+      experiment flag at
+      <b>chrome://flags/#privacy-sandbox-ads-apis</b>
+      with Chrome 104.0.5086.0 and above to test this Shared Storage API demo.
+    </p>
+  </card>
+</main>
+<script defer>
+  checkSharedStorage()
+</script>

--- a/sites/content-producer/use-cases/third-party-write.html
+++ b/sites/content-producer/use-cases/third-party-write.html
@@ -1,0 +1,58 @@
+<!--
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" />
+    <meta name="description" content="Demo of various Shared Storage use-cases" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
+    <title>Shared storage demo</title>
+
+    <link rel="stylesheet" href="https://unpkg.com/open-props" />
+    <link rel="stylesheet" href="https://unpkg.com/open-props/normalize.min.css" />
+    <link rel="stylesheet" href="https://unpkg.com/open-props/buttons.min.css" />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🙂</text></svg>"
+    />
+    <link rel="stylesheet" href="../demo.css" />
+    <script>
+      function resetDemo() {
+        sharedStorage.delete('third-party-write-demo')
+        parent.postMessage('clear-publisher-data', '*')
+      }
+
+      function runDemo() {
+        sharedStorage.set('third-party-write-demo', "written into third-party storage by third-party code")
+        parent.postMessage('run-third-party-write-demo', '*')
+      }
+    </script>
+  </head>
+
+  <body>
+    <div class="demo__controls">
+      <h5>Demo control</h5>
+      <div class="demo__buttons-container">
+        <button class="mdl-button mdl-js-button mdl-button--raised demo__button" onclick="runDemo()">
+          Write to both publisher's and third-party's shared storage
+        </button>
+        <button class="mdl-button mdl-js-button mdl-button--raised demo__button" onclick="resetDemo()">
+          Delete publisher and third-party demo data
+        </button>
+      </div>
+    </div>
+  </body>
+</html>

--- a/sites/content-producer/use-cases/third-party-write.js
+++ b/sites/content-producer/use-cases/third-party-write.js
@@ -1,0 +1,10 @@
+window.addEventListener('message', ({ data }) => {
+  switch (data) {
+    case 'run-third-party-write-demo': 
+      window.sharedStorage.set('third-party-write-demo', 'written into publisher storage by third-party code');
+      break;
+    case 'clear-publisher-data': 
+      window.sharedStorage.delete('third-party-write-demo');
+      break;
+  }
+});


### PR DESCRIPTION
This PR adds a use case for controlling where a third-party can write data into.