### PR TITLE
Remove "this" keyword

### DIFF
--- a/functions/app/content-producer/paa/scripts/private-aggregation-test-worklet.js
+++ b/functions/app/content-producer/paa/scripts/private-aggregation-test-worklet.js
@@ -18,8 +18,8 @@ const DEBUG_MODE_CHANCE = 0.5;
 
 class PrivateAggregationTest {
   async run() {
-    const testKey = await this.sharedStorage.get('test-key');
-    const testValue = await this.sharedStorage.get('test-value');
+    const testKey = await sharedStorage.get('test-key');
+    const testValue = await sharedStorage.get('test-value');
 
     if (!testKey || !testValue) {
       return;
@@ -35,8 +35,8 @@ class PrivateAggregationTest {
       value: parseInt(testValue),
     });
 
-    this.sharedStorage.delete('test-key');
-    this.sharedStorage.delete('test-value');
+    sharedStorage.delete('test-key');
+    sharedStorage.delete('test-value');
   }
 }
 

--- a/sites/content-producer/private-aggregation/demographics-measurement-worklet.js
+++ b/sites/content-producer/private-aggregation/demographics-measurement-worklet.js
@@ -83,9 +83,9 @@ class DemographicsMeasurementOperation {
 
       // Read from Shared Storage
       const key = 'has-reported-content';
-      const hasReportedContent = (await this.sharedStorage.get(key)) === 'true';
-      const ageGroup = await this.sharedStorage.get('age-group');
-      const continent = await this.sharedStorage.get('continent');
+      const hasReportedContent = (await sharedStorage.get(key)) === 'true';
+      const ageGroup = await sharedStorage.get('age-group');
+      const continent = await sharedStorage.get('continent');
 
       // Do not report if a report has been sent already
       if (hasReportedContent) {
@@ -109,7 +109,7 @@ class DemographicsMeasurementOperation {
       privateAggregation.sendHistogramReport({ bucket, value });
 
       // Set the report submission status flag
-      await this.sharedStorage.set(key, true);
+      await sharedStorage.set(key, true);
 
       console.log(`[PAA] Unique reach measurement report will be submitted for Content ID ${data.contentId}`);
       console.log(`[PAA] The aggregation key is ${bucket} and the aggregatable value is ${value}`);

--- a/sites/content-producer/private-aggregation/k-freq-measurement-worklet.js
+++ b/sites/content-producer/private-aggregation/k-freq-measurement-worklet.js
@@ -48,8 +48,8 @@ class KFreqMeasurementOperation {
       // Read from Shared Storage
       const hasReportedContentKey = 'has-reported-content';
       const impressionCountKey = 'impression-count';
-      const hasReportedContent = (await this.sharedStorage.get(hasReportedContentKey)) === 'true';
-      const impressionCount = parseInt((await this.sharedStorage.get(impressionCountKey)) || 0);
+      const hasReportedContent = (await sharedStorage.get(hasReportedContentKey)) === 'true';
+      const impressionCount = parseInt((await sharedStorage.get(impressionCountKey)) || 0);
 
       // Do not report if a report has been sent already
       if (hasReportedContent) {
@@ -64,7 +64,7 @@ class KFreqMeasurementOperation {
         console.log(
           `[PAA] Current impression count is ${impressionCount} and has not met the K threashold of ${kFreq}`
         );
-        await this.sharedStorage.set(impressionCountKey, impressionCount + 1);
+        await sharedStorage.set(impressionCountKey, impressionCount + 1);
         return;
       }
 
@@ -77,7 +77,7 @@ class KFreqMeasurementOperation {
       privateAggregation.sendHistogramReport({ bucket, value });
 
       // Set the report submission status flag
-      await this.sharedStorage.set(hasReportedContentKey, 'true');
+      await sharedStorage.set(hasReportedContentKey, 'true');
 
       console.log(`[PAA] Current impression count is ${impressionCount} which meets the K threashold of ${kFreq}`);
       console.log('[PAA] K-frequency measurement report will be submitted');

--- a/sites/content-producer/private-aggregation/reach-measurement-worklet.js
+++ b/sites/content-producer/private-aggregation/reach-measurement-worklet.js
@@ -46,7 +46,7 @@ class ReachMeasurementOperation {
 
       // Read from Shared Storage
       const key = 'has-reported-content';
-      const hasReportedContent = (await this.sharedStorage.get(key)) === 'true';
+      const hasReportedContent = (await sharedStorage.get(key)) === 'true';
 
       // Do not report if a report has been sent already
       if (hasReportedContent) {
@@ -65,7 +65,7 @@ class ReachMeasurementOperation {
       privateAggregation.sendHistogramReport({ bucket, value });
 
       // Set the report submission status flag
-      await this.sharedStorage.set(key, true);
+      await sharedStorage.set(key, true);
 
       console.log(`[PAA] Unique reach measurement report will be submitted for Content ID ${contentId}`);
       console.log(`[PAA] The aggregation key is ${bucket} and the aggregatable value is ${value}`);

--- a/sites/content-producer/url-selection/ab-testing-worklet.js
+++ b/sites/content-producer/url-selection/ab-testing-worklet.js
@@ -18,7 +18,7 @@
 class SelectURLOperation {
   async run(urls, data) {
     // Read the user's group from shared storage
-    const experimentGroup = await this.sharedStorage.get('ab-testing-group');
+    const experimentGroup = await sharedStorage.get('ab-testing-group');
 
     // Log to console for the demo
     console.log(`urls = ${JSON.stringify(urls)}`);

--- a/sites/content-producer/url-selection/creative-rotation-worklet.js
+++ b/sites/content-producer/url-selection/creative-rotation-worklet.js
@@ -17,7 +17,7 @@
 class SelectURLOperation {
   async run(urls, data) {
     // Read the rotation mode from Shared Storage
-    const rotationMode = await this.sharedStorage.get('creative-rotation-mode');
+    const rotationMode = await sharedStorage.get('creative-rotation-mode');
 
     // Generate a random number to be used for rotation
     const randomNumber = Math.random();
@@ -31,13 +31,13 @@ class SelectURLOperation {
        * - Example: A -> B -> C -> A ...
        */
       case 'sequential':
-        const currentIndex = await this.sharedStorage.get('creative-rotation-index');
+        const currentIndex = await sharedStorage.get('creative-rotation-index');
         index = parseInt(currentIndex, 10);
         const nextIndex = (index + 1) % urls.length;
 
         console.log(`index = ${index} / next index = ${nextIndex}`);
 
-        await this.sharedStorage.set('creative-rotation-index', nextIndex.toString());
+        await sharedStorage.set('creative-rotation-index', nextIndex.toString());
         break;
 
       /**

--- a/sites/content-producer/url-selection/creative-selection-by-frequency-worklet.js
+++ b/sites/content-producer/url-selection/creative-selection-by-frequency-worklet.js
@@ -19,7 +19,7 @@ const FREQUENCY_LIMIT = 5;
 class CreativeSelectionByFrequencyOperation {
   async run(urls, data) {
     // Read the current frequency cap in shared storage
-    const count = parseInt(await this.sharedStorage.get('frequency-count'));
+    const count = parseInt(await sharedStorage.get('frequency-count'));
 
     // Log to console for the demo
     console.log(`urls = ${JSON.stringify(urls)}`);
@@ -32,7 +32,7 @@ class CreativeSelectionByFrequencyOperation {
     }
 
     // Increment the frequency
-    await this.sharedStorage.set('frequency-count', count + 1);
+    await sharedStorage.set('frequency-count', count + 1);
     return 1;
   }
 }

--- a/sites/content-producer/url-selection/known-customer-worklet.js
+++ b/sites/content-producer/url-selection/known-customer-worklet.js
@@ -16,7 +16,7 @@
 
 class SelectURLOperation {
   async run(urls) {
-    const knownCustomer = await this.sharedStorage.get('known-customer');
+    const knownCustomer = await sharedStorage.get('known-customer');
 
     console.log(`urls = ${JSON.stringify(urls)}`);
     console.log(`known-customer value is ${knownCustomer}`);


### PR DESCRIPTION
This PR removes the `this` keyword used in the worklet, which is now breaking the Canary build.  It was never supposed to work to begin with, and the new behavior is the correct behavior. 