### PR TITLE
update decoder.js .decoder__bucket--decimal and .decoder__value--decimal

### DIFF
--- a/sites/home/decoder/decoder.js
+++ b/sites/home/decoder/decoder.js
@@ -19,9 +19,9 @@ const ZEROES_FOR_PADDING = '00000000';
 
 function renderOutput({ bucketInBinary, valueInBinary }) {
   document.querySelector('.decoder__bucket--binary').innerHTML = bucketInBinary;
-  document.querySelector('.decoder__bucket--decimal').innerHTML = BigInt("0b" + bucketInBinary);
+  document.querySelector('.decoder__bucket--decimal').innerHTML = BigInt(`0b${bucketInBinary}`);
   document.querySelector('.decoder__value--binary').innerHTML = valueInBinary;
-  document.querySelector('.decoder__value--decimal').innerHTML = BigInt("0b" + valueInBinary);
+  document.querySelector('.decoder__value--decimal').innerHTML = BigInt(`0b${valueInBinary}`);
 }
 
 // Converts the number to a binary string

--- a/sites/home/decoder/decoder.js
+++ b/sites/home/decoder/decoder.js
@@ -19,9 +19,9 @@ const ZEROES_FOR_PADDING = '00000000';
 
 function renderOutput({ bucketInBinary, valueInBinary }) {
   document.querySelector('.decoder__bucket--binary').innerHTML = bucketInBinary;
-  document.querySelector('.decoder__bucket--decimal').innerHTML = BigInt(parseInt(bucketInBinary, 2));
+  document.querySelector('.decoder__bucket--decimal').innerHTML = BigInt("0b" + bucketInBinary);
   document.querySelector('.decoder__value--binary').innerHTML = valueInBinary;
-  document.querySelector('.decoder__value--decimal').innerHTML = BigInt(parseInt(valueInBinary, 2));
+  document.querySelector('.decoder__value--decimal').innerHTML = BigInt("0b" + valueInBinary);
 }
 
 // Converts the number to a binary string


### PR DESCRIPTION
Updating the .decoder__bucket--decimal and .decoder__value--decimal to use BigInt instead of using parseInt.

parseInt has a maximum of 52 bits and anything beyond 52 bits does not convert very well.

Bucket keys have a maximum of 128 bits and using just BigInt with a binary signature will help convert the binary correctly.