### PR TITLE
Update Private Aggregation calls to use the newer names

### DIFF
--- a/functions/app/content-producer/paa/scripts/private-aggregation-test-worklet.js
+++ b/functions/app/content-producer/paa/scripts/private-aggregation-test-worklet.js
@@ -26,11 +26,11 @@ class PrivateAggregationTest {
     }
 
     if (Math.random() < DEBUG_MODE_CHANCE) {
-      const debug_key = BigInt(54321);
-      privateAggregation.enableDebugMode({ debug_key });
+      const debugKey = BigInt(54321);
+      privateAggregation.enableDebugMode({ debugKey });
     }
 
-    privateAggregation.sendHistogramReport({
+    privateAggregation.contributeToHistogram({
       bucket: BigInt(testKey),
       value: parseInt(testValue),
     });

--- a/sites/content-producer/private-aggregation/demographics-measurement-worklet.js
+++ b/sites/content-producer/private-aggregation/demographics-measurement-worklet.js
@@ -79,7 +79,7 @@ function generateAggregationKey(contentId, ageGroup, continent) {
 class DemographicsMeasurementOperation {
   async run(data) {
     try {
-      const { contentId, debug_key } = data;
+      const { contentId, debugKey } = data;
 
       // Read from Shared Storage
       const key = 'has-reported-content';
@@ -105,8 +105,8 @@ class DemographicsMeasurementOperation {
       const value = 1 * SCALE_FACTOR;
 
       // Send an aggregatable report via the Private Aggregation API
-      privateAggregation.enableDebugMode({ debug_key });
-      privateAggregation.sendHistogramReport({ bucket, value });
+      privateAggregation.enableDebugMode({ debugKey });
+      privateAggregation.contributeToHistogram({ bucket, value });
 
       // Set the report submission status flag
       await sharedStorage.set(key, true);

--- a/sites/content-producer/private-aggregation/demographics-measurement.js
+++ b/sites/content-producer/private-aggregation/demographics-measurement.js
@@ -18,7 +18,7 @@ async function measureDemographics() {
   await window.sharedStorage.worklet.addModule('demographics-measurement-worklet.js');
 
   // Run the demographics measurement operation
-  await window.sharedStorage.run('demographics-measurement', { data: { contentId: '123', debug_key: 888n } });
+  await window.sharedStorage.run('demographics-measurement', { data: { contentId: '123', debugKey: 888n } });
 }
 
 measureDemographics();

--- a/sites/content-producer/private-aggregation/k-freq-measurement-worklet.js
+++ b/sites/content-producer/private-aggregation/k-freq-measurement-worklet.js
@@ -43,7 +43,7 @@ function convertContentIdToBucket(contentId) {
 class KFreqMeasurementOperation {
   async run(data) {
     try {
-      const { kFreq, contentId, debug_key } = data;
+      const { kFreq, contentId, debugKey } = data;
 
       // Read from Shared Storage
       const hasReportedContentKey = 'has-reported-content';
@@ -73,8 +73,8 @@ class KFreqMeasurementOperation {
       const value = 1 * SCALE_FACTOR;
 
       // Send an aggregatable report via the Private Aggregation API
-      privateAggregation.enableDebugMode({ debug_key });
-      privateAggregation.sendHistogramReport({ bucket, value });
+      privateAggregation.enableDebugMode({ debugKey });
+      privateAggregation.contributeToHistogram({ bucket, value });
 
       // Set the report submission status flag
       await sharedStorage.set(hasReportedContentKey, 'true');

--- a/sites/content-producer/private-aggregation/k-freq-measurement.js
+++ b/sites/content-producer/private-aggregation/k-freq-measurement.js
@@ -19,7 +19,7 @@ async function injectAd() {
   await window.sharedStorage.worklet.addModule('k-freq-measurement-worklet.js');
 
   // Run the K-frequency measurement operation
-  await window.sharedStorage.run('k-freq-measurement', { data: { kFreq: 3, contentId: 123, debug_key: 999n } });
+  await window.sharedStorage.run('k-freq-measurement', { data: { kFreq: 3, contentId: 123, debugKey: 999n } });
 }
 
 injectAd();

--- a/sites/content-producer/private-aggregation/reach-measurement-worklet.js
+++ b/sites/content-producer/private-aggregation/reach-measurement-worklet.js
@@ -42,7 +42,7 @@ function convertContentIdToBucket(contentId) {
 class ReachMeasurementOperation {
   async run(data) {
     try {
-      const { contentId, debug_key } = data;
+      const { contentId, debugKey } = data;
 
       // Read from Shared Storage
       const key = 'has-reported-content';
@@ -61,8 +61,8 @@ class ReachMeasurementOperation {
       const value = 1 * SCALE_FACTOR;
 
       // Send an aggregatable report via the Private Aggregation API
-      privateAggregation.enableDebugMode({ debug_key });
-      privateAggregation.sendHistogramReport({ bucket, value });
+      privateAggregation.enableDebugMode({ debugKey });
+      privateAggregation.contributeToHistogram({ bucket, value });
 
       // Set the report submission status flag
       await sharedStorage.set(key, true);

--- a/sites/content-producer/private-aggregation/reach-measurement.js
+++ b/sites/content-producer/private-aggregation/reach-measurement.js
@@ -18,7 +18,7 @@ async function measureUniqueReach() {
   await window.sharedStorage.worklet.addModule('reach-measurement-worklet.js');
 
   // Run the reach measurement operation
-  await window.sharedStorage.run('reach-measurement', { data: { contentId: '1234', debug_key: 777n } });
+  await window.sharedStorage.run('reach-measurement', { data: { contentId: '1234', debugKey: 777n } });
 }
 
 measureUniqueReach();


### PR DESCRIPTION
Specifically, debug_key -> debugKey and sendHistogramReport -> contributeToHistogram. See this announcement for more details: https://groups.google.com/a/chromium.org/g/shared-storage-api-announcements/c/YHloqvcUUhY/m/6L6dSf1PAAAJ