### PR TITLE
Update flag instructions for shared storage

### DIFF
--- a/functions/view/home/index.hbs
+++ b/functions/view/home/index.hbs
@@ -20,7 +20,7 @@
       <a href='https://github.com/GoogleChromeLabs/shared-storage-demo' target='_blank'>GitHub</a>.</p>
 
     <h4>How to run the demo</h4>
-    <img src='https://wd.imgix.net/image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/CWfgCMJQ5cYPOfjttF3k.png?auto=format&w=700' />
+    <img src='https://wd.imgix.net/image/jc12tn44ghWnPdtbfjsmxHEaCUC3/ioMgXCp8CAyumX9Qqrgb.png?auto=format&w=700' />
     <br />
     <p>To run the URL selection demo,
       <a
@@ -30,7 +30,9 @@
       for enabling the
       <b>Privacy Sandbox Ads APIs</b>
       experiment flag at
-      <b>chrome://flags/#privacy-sandbox-ads-apis</b>.</p>
+      <b>chrome://flags/#privacy-sandbox-ads-apis</b> and <b>chrome://flags/#privacy-sandbox-enrollment-overrides</b>, using the following value for the latter:
+      <code>https://shared-storage-demo-content-producer.web.app,https://shared-storage-demo-publisher-a.web.app</code> 
+      </p>
   </div>
   <section class='demo__card-container'>
         <section class='demo__gate-container'>


### PR DESCRIPTION
Adding instructions for setting the `#privacy-sandbox-enrollment-overrides` flag and updating the screenshot to match.